### PR TITLE
Fix CI: workflow can't specify both uses: and run:

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,9 +40,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Check clippy
-        run: rustup component add clippy
-        uses: actions-rs/clippy-check@v1
+      - run: rustup component add clippy
+      - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-targets --all-features -- -D clippy::all

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,6 @@ jobs:
         - uses: actions-rs/cargo@v1
           with:
             command: test
-            args: --show-output
 
   static_checks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
#### Summary

CI runs have been failing: https://github.com/sigstore/sget/actions/workflows/main.yml

Example taken from https://github.com/actions-rs/clippy-check#with-stable-clippy


#### Release Note

```release-note
NONE
```