### PR TITLE
Add CI status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # sget
 
+[![CI](https://github.com/sigstore/sget/actions/workflows/main.yml/badge.svg)](https://github.com/sigstore/sget/actions/workflows/main.yml)
+
 > :warning: Not ready for use yet! :warning:  
 
 sget is a keyless safe script retrieval and execution tool.


### PR DESCRIPTION
When CI is able to run again (#33) this should give us a pretty badge 🥇 

```release-note
NONE
```