### PR TITLE
Skip execute script test on Windows

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -27,6 +27,7 @@ fn execute_script_fail() {
 }
 
 #[test]
+#[cfg(not(target_os = "windows"))]
 fn execute_script_success() {
     let mut dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     dir.push("tests/test.sh");


### PR DESCRIPTION
This is a temporary workaround. Hopefully it will work; I'm not sure how to test it on Windows.