### PR TITLE
Clean up serialization / deserialization and add struct to hold raw signed value from Policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,6 +1093,7 @@ dependencies = [
 name = "sget"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "chrono",
  "clap 3.0.0-beta.5",
  "oci-distribution",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0"
 chrono = { version = "0.4.11", features = ["serde"] }
 clap = "3.0.0-beta.5"
 serde_json = "1.0.68"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 anyhow = "1.0"
 chrono = { version = "0.4.11", features = ["serde"] }
 clap = "3.0.0-beta.5"
-serde_json = "1.0.68"
+serde_json = { version = "1.0", features = ["raw_value"] }
 serde = {version = "1.0.130", features = ["derive"]}
 serde_plain = "1.0.0"
 serde_with = { version = "1.8.0", features = ["json"]}

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Error, Result};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{value::RawValue, Value};
 use serde_plain::{derive_display_from_serialize, derive_fromstr_from_deserialize};
 use std::{collections::HashMap, convert::TryFrom, num::NonZeroU64};
 
@@ -18,6 +18,17 @@ impl Policy {
     pub fn validate_expires(&self) -> chrono::Duration {
         self.signed.expires.signed_duration_since(Utc::now())
     }
+}
+
+// This holds the raw data from a serialized policy, accessible via the
+// 'signatures' and 'signed' fields. We must preserve this data as RawValues
+// in order for signature verification to work.
+#[derive(Serialize, Deserialize)]
+struct RawPolicy<'a> {
+    #[serde(borrow)]
+    pub signatures: &'a RawValue,
+    #[serde(borrow)]
+    pub signed: &'a RawValue,
 }
 
 // A signature and the key ID and certificate that made it.


### PR DESCRIPTION
In this PR:

- Clean up some tests
- Change the `role` field to a String, which allows ser/de to work correctly (add method to convert String to `RoleType`). Also reordered the struct fields in the Policy so the debug output matches the raw file and is easier to read and serialize/deserialize.
- Add a RawPolicy struct to hold the raw JSON

This last one is important because without it we cannot verify signatures on the Root.