### PR TITLE
Outfile requires

### DIFF
--- a/file.sh
+++ b/file.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-echo "Hello sget!"

--- a/file.sh
+++ b/file.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "Hello sget!"

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,6 +71,7 @@ async fn main() {
                 .long("noexec")
                 .takes_value(false)
                 .requires("oci-registry")
+                .requires("outfile")
                 .about("Do not execute script"),
         )
         .arg(


### PR DESCRIPTION
noexec requires outfile, so to save a panic, set it accordingly

in time we can look to handle a result here instead

Signed-off-by: Luke Hinds <lhinds@redhat.com>
